### PR TITLE
Add event endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,14 @@ Where `marathon-consul.json` is similar to (replacing the image with your image)
 
 You can also add [options to authenticate against Consul](#options).
 
-The Marathon event bus should point to [`/events``](#endpoints). You can
-set up the event subscription with a call similar to this one:
+If your version of Marathon is 0.10.0 or newer, no further setup is required.
+Marathon-consul will autodetect the /v2/events endpoint and use it to update
+Consul.
+
+If your version of Marathon does not have the event bus endpoint, you must
+configure an event subscription. *The Marathon event bus should point to
+[`/events``](#endpoints)*. You can set up the event subscription with a call
+similar to this one:
 
 ```
 curl -X POST 'http://marathon.service.consul:8080/v2/eventSubscriptions?callbackUrl=http://marathon-consul.service.consul:4000/events'

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Where `marathon-consul.json` is similar to (replacing the image with your image)
 
 You can also add [options to authenticate against Consul](#options).
 
-If your version of Marathon is 0.10.0 or newer, no further setup is required.
+If your version of Marathon is 0.9.0 or newer, no further setup is required.
 Marathon-consul will autodetect the /v2/events endpoint and use it to update
 Consul.
 

--- a/events/parse.go
+++ b/events/parse.go
@@ -62,5 +62,5 @@ func ParseEvent(jsonBlob []byte) (event Event, err error) {
 		return nil, errors.New("Unknown event type: " + eventType)
 	}
 
-	return nil, errors.New(fmt.Sprintf("Error processing event type: %s: %s", eventType, err.Error()))
+	return nil, fmt.Errorf("Error processing event type: %s: %s", eventType, err.Error())
 }

--- a/events/parse.go
+++ b/events/parse.go
@@ -3,6 +3,7 @@ package events
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 )
 
 var (
@@ -47,17 +48,19 @@ func parseAppTerminatedEvent(jsonBlob []byte) (Event, error) {
 func ParseEvent(jsonBlob []byte) (event Event, err error) {
 	eventType, err := EventType(jsonBlob)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	switch eventType {
 	case "api_post_event":
-		event, err = parseAPIPostEvent(jsonBlob)
+		return parseAPIPostEvent(jsonBlob)
 	case "deployment_info":
-		event, err = parseDeploymentInfoEvent(jsonBlob)
+		return parseDeploymentInfoEvent(jsonBlob)
 	case "app_terminated_event":
-		event, err = parseAppTerminatedEvent(jsonBlob)
+		return parseAppTerminatedEvent(jsonBlob)
+	default:
+		return nil, errors.New("Unknown event type: " + eventType)
 	}
 
-	return
+	return nil, errors.New(fmt.Sprintf("Error processing event type: %s: %s", eventType, err.Error()))
 }

--- a/main.go
+++ b/main.go
@@ -66,7 +66,6 @@ func SubscribeToEventStream(config *config.Config, m marathon.Marathon, fh *Forw
 		os.Exit(1)
 	}
 	defer resp.Body.Close()
-	log.Info("reader here")
 	reader := bufio.NewReader(resp.Body)
 
 	for {
@@ -94,22 +93,23 @@ func SubscribeToEventStream(config *config.Config, m marathon.Marathon, fh *Forw
 				continue
 			}
 
+			eventLogger := log.WithField("eventType", eventType)
 			switch eventType {
 			case "api_post_event", "deployment_info":
-				log.WithField("eventType", eventType).Info("handling event")
+				eventLogger.Info("handling event")
 				err = fh.HandleAppEvent(body)
 			case "app_terminated_event":
-				log.WithField("eventType", "app_terminated_event").Info("handling event")
+				eventLogger.Info("handling event")
 				err = fh.HandleTerminationEvent(body)
 			case "status_update_event":
-				log.WithField("eventType", "status_update_event").Info("handling event")
+				eventLogger.Info("handling event")
 				err = fh.HandleStatusEvent(body)
 			default:
-				log.WithField("eventType", eventType).Info("not handling event")
+				eventLogger.Info("not handling event")
 			}
 
 			if err != nil {
-				log.WithError(err).Error("body generated error")
+				eventLogger.WithError(err).Error("body generated error")
 				continue
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net/http"
+	"os"
+
 	"github.com/CiscoCloud/marathon-consul/config"
 	"github.com/CiscoCloud/marathon-consul/consul"
+	"github.com/CiscoCloud/marathon-consul/events"
 	"github.com/CiscoCloud/marathon-consul/marathon"
 	log "github.com/Sirupsen/logrus"
-	"net/http"
 )
 
 const Name = "marathon-consul"
@@ -33,10 +39,86 @@ func main() {
 	sync := marathon.NewMarathonSync(remote, consul)
 	go sync.Sync()
 
-	// set up routes
+	fh := &ForwardHandler{consul}
+
+	version, err := remote.Version()
+	if version > "0.10.0" {
+		log.Info(fmt.Sprintf("detected Marathon v%s with /v2/events endpoint", version))
+		SubscribeToEventStream(config, remote, fh)
+	} else {
+		log.Info(fmt.Sprintf("detected Marathon v%s -- make sure to set up an eventSubscription for this process", version))
+		ServeWebhookReceiver(config, fh)
+	}
+}
+
+func SubscribeToEventStream(config *config.Config, m marathon.Marathon, fh *ForwardHandler) {
+	buffer := make([]byte, 1024)
+	req, err := http.NewRequest("GET", m.Url("/v2/events"), bytes.NewBuffer(buffer))
+	if err != nil {
+		log.WithError(err).Error("Could not GET /v2/events")
+		os.Exit(1)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.WithError(err).Error("HTTP request for /v2/events failed!")
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+	log.Info("reader here")
+	reader := bufio.NewReader(resp.Body)
+
+	for {
+		body, err := reader.ReadBytes('\n')
+		if err != nil {
+			panic(err)
+		}
+
+		// marathon sends blank lines to keep the connection alive
+		if bytes.Equal(body, []byte{'\r', '\n'}) {
+			continue
+		}
+
+		// we don't care about these headers, since the data blob has an
+		// "eventType" field
+		if string(body[0:6]) == "event:" {
+			continue
+		}
+
+		if string(body[0:5]) == "data:" {
+			body = body[6:]
+			eventType, err := events.EventType(body)
+			if err != nil {
+				log.WithError(err).Error("error parsing event")
+				continue
+			}
+
+			switch eventType {
+			case "api_post_event", "deployment_info":
+				log.WithField("eventType", eventType).Info("handling event")
+				err = fh.HandleAppEvent(body)
+			case "app_terminated_event":
+				log.WithField("eventType", "app_terminated_event").Info("handling event")
+				err = fh.HandleTerminationEvent(body)
+			case "status_update_event":
+				log.WithField("eventType", "status_update_event").Info("handling event")
+				err = fh.HandleStatusEvent(body)
+			default:
+				log.WithField("eventType", eventType).Info("not handling event")
+			}
+
+			if err != nil {
+				log.WithError(err).Error("body generated error")
+				continue
+			}
+		}
+	}
+}
+
+func ServeWebhookReceiver(config *config.Config, fh *ForwardHandler) {
 	http.HandleFunc("/health", HealthHandler)
-	forwarderHandler := &ForwardHandler{consul}
-	http.HandleFunc("/events", forwarderHandler.Handle)
+	http.HandleFunc("/events", fh.Handle)
 
 	log.WithField("port", config.Web.Listen).Info("listening")
 	log.Fatal(http.ListenAndServe(config.Web.Listen, nil))

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"net/http"
 	"os"
 	"time"
@@ -51,10 +50,10 @@ func main() {
 	minVersion, _ := version.NewConstraint(">= 0.9.0")
 
 	if minVersion.Check(v) {
-		log.Info(fmt.Sprintf("detected Marathon v%s with /v2/events endpoint", v))
+		log.WithField("version", v).Info("detected Marathon events endpoint")
 		SubscribeToEventStream(config, remote, fh)
 	} else {
-		log.Info(fmt.Sprintf("detected Marathon v%s -- make sure to set up an eventSubscription for this process", v))
+		log.WithField("version", v).Info("detected old Marathon version -- make sure to set up an eventSubscription for this process")
 		ServeWebhookReceiver(config, fh)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 	fh := &ForwardHandler{consul}
 
 	version, err := remote.Version()
-	if version > "0.10.0" {
+	if version >= "0.9.0" {
 		log.Info(fmt.Sprintf("detected Marathon v%s with /v2/events endpoint", version))
 		SubscribeToEventStream(config, remote, fh)
 	} else {

--- a/marathon/marathon_test.go
+++ b/marathon/marathon_test.go
@@ -14,6 +14,58 @@ func TestUrl(t *testing.T) {
 	assert.Equal(t, url, "http://localhost:8080/v2/apps")
 }
 
+func TestParseVersion(t *testing.T) {
+	t.Parallel()
+
+	infoBlob := []byte(`{
+		"http_config": {
+			"https_port": 8443,
+			"http_port": 8080,
+			"assets_path": null
+		},
+		"name": "marathon",
+		"version": "0.11.1",
+		"elected": true,
+		"leader": "marathon-leader.example.com:8080",
+		"frameworkId": "20150714-191408-4163031306-5050-1590-0000",
+		"marathon_config": {
+			"mesos_leader_ui_url": "http://marathon-leader.example.com:5050/",
+			"leader_proxy_read_timeout_ms": 10000,
+			"leader_proxy_connection_timeout_ms": 5000,
+			"executor": "//cmd",
+			"local_port_max": 20000,
+			"local_port_min": 10000,
+			"checkpoint": true,
+			"ha": true,
+			"framework_name": "marathon",
+			"failover_timeout": 604800,
+			"master": "zk://zk.example.com:2181/mesos",
+			"hostname": "marathon-leader.example.com",
+			"webui_url": null,
+			"mesos_role": null,
+			"task_launch_timeout": 300000,
+			"reconciliation_initial_delay": 15000,
+			"reconciliation_interval": 300000,
+			"marathon_store_timeout": 2000,
+			"mesos_user": "root"
+		},
+		"zookeeper_config": {
+			"zk_max_versions": 25,
+			"zk_session_timeout": 1800000,
+			"zk_timeout": 10000,
+			"zk": "zk://zk.example.com:2181/marathon"
+		},
+		"event_subscriber": {
+			"http_endpoints": null,
+			"type": "http_callback"
+		}
+  }`)
+	m, _ := NewMarathon("localhost:8080", "http", nil)
+	version, err := m.ParseInfo(infoBlob)
+	assert.Equal(t, version, "0.11.1")
+	assert.Nil(t, err)
+}
+
 func TestParseApps(t *testing.T) {
 	t.Parallel()
 

--- a/marathon/marathon_test.go
+++ b/marathon/marathon_test.go
@@ -1,8 +1,10 @@
 package marathon
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	version "github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUrl(t *testing.T) {
@@ -61,8 +63,12 @@ func TestParseVersion(t *testing.T) {
 		}
   }`)
 	m, _ := NewMarathon("localhost:8080", "http", nil)
-	version, err := m.ParseInfo(infoBlob)
-	assert.Equal(t, version, "0.11.1")
+	v, err := m.ParseVersion(infoBlob)
+	assert.Equal(t, v, "0.11.1")
+	assert.Nil(t, err)
+
+	// quickly verify that this version can be parsed with the version library
+	_, err = version.NewVersion(v)
 	assert.Nil(t, err)
 }
 

--- a/marathon/sync.go
+++ b/marathon/sync.go
@@ -39,6 +39,7 @@ func (m *MarathonSync) Sync() error {
 			return err
 		}
 	}
+	log.Info("synced!")
 
 	return nil
 }

--- a/web.go
+++ b/web.go
@@ -56,7 +56,7 @@ func (fh *ForwardHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.WriteHeader(500)
 		fmt.Fprintln(w, err.Error())
-		log.Printf("[ERROR] body generated error: %s", err.Error())
+		log.WithError(err).Error("body generated error")
 	} else {
 		w.WriteHeader(200)
 		fmt.Fprintln(w, "OK")
@@ -87,12 +87,7 @@ func (fh *ForwardHandler) HandleTerminationEvent(body []byte) error {
 
 	// app_terminated_event only has one app in it, so we will just take care of
 	// it instead of looping
-	err = fh.consul.DeleteApp(event.Apps()[0])
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return fh.consul.DeleteApp(event.Apps()[0])
 }
 
 func (fh *ForwardHandler) HandleStatusEvent(body []byte) error {
@@ -116,10 +111,5 @@ func (fh *ForwardHandler) HandleStatusEvent(body []byte) error {
 	default:
 		err = errors.New("unknown task status")
 	}
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/web.go
+++ b/web.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/CiscoCloud/marathon-consul/consul"
 	"github.com/CiscoCloud/marathon-consul/events"
 	"github.com/CiscoCloud/marathon-consul/tasks"
 	log "github.com/Sirupsen/logrus"
-	"io/ioutil"
-	"net/http"
 )
 
 func HealthHandler(w http.ResponseWriter, r *http.Request) {
@@ -38,72 +39,63 @@ func (fh *ForwardHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	switch eventType {
 	case "api_post_event", "deployment_info":
 		log.WithField("eventType", eventType).Info("handling event")
-		fh.HandleAppEvent(w, body)
+		err = fh.HandleAppEvent(body)
 	case "app_terminated_event":
 		log.WithField("eventType", "app_terminated_event").Info("handling event")
-		fh.HandleTerminationEvent(w, body)
+		err = fh.HandleTerminationEvent(body)
 	case "status_update_event":
 		log.WithField("eventType", "status_update_event").Info("handling event")
-		fh.HandleStatusEvent(w, body)
+		err = fh.HandleStatusEvent(body)
 	default:
 		log.WithField("eventType", eventType).Info("not handling event")
 		w.WriteHeader(200)
 		fmt.Fprintf(w, "cannot handle %s\n", eventType)
+		return
+	}
+
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintln(w, err.Error())
+		log.Printf("[ERROR] body generated error: %s", err.Error())
+	} else {
+		w.WriteHeader(200)
+		fmt.Fprintln(w, "OK")
 	}
 	log.Debug(string(body))
 }
 
-func (fh *ForwardHandler) HandleAppEvent(w http.ResponseWriter, body []byte) {
+func (fh *ForwardHandler) HandleAppEvent(body []byte) error {
 	event, err := events.ParseEvent(body)
 	if err != nil {
-		w.WriteHeader(500)
-		fmt.Fprintln(w, err.Error())
-		log.Printf("[ERROR] body generated error: %s", err.Error())
-		return
+		return err
 	}
 
-	resp := ""
-	respCode := 200
 	for _, app := range event.Apps() {
 		err = fh.consul.UpdateApp(app)
 		if err != nil {
-			resp += err.Error() + "\n"
-			log.Printf("[ERROR] response generated error: %s", err.Error())
-			respCode = 500
+			return err
 		}
 	}
-
-	if resp == "" {
-		resp = "OK\n"
-	}
-
-	w.WriteHeader(respCode)
-	fmt.Fprint(w, resp)
+	return nil
 }
 
-func (fh *ForwardHandler) HandleTerminationEvent(w http.ResponseWriter, body []byte) {
+func (fh *ForwardHandler) HandleTerminationEvent(body []byte) error {
 	event, err := events.ParseEvent(body)
 	if err != nil {
-		w.WriteHeader(500)
-		fmt.Fprintln(w, err.Error())
-		log.Printf("[ERROR] body generated error: %s", err.Error())
-		return
+		return err
 	}
 
 	// app_terminated_event only has one app in it, so we will just take care of
 	// it instead of looping
 	err = fh.consul.DeleteApp(event.Apps()[0])
 	if err != nil {
-		w.WriteHeader(500)
-		fmt.Fprintln(w, err.Error())
-		log.Printf("[ERROR] response generated error: %s", err.Error())
-	} else {
-		w.WriteHeader(200)
-		fmt.Fprintln(w, "OK")
+		return err
 	}
+
+	return nil
 }
 
-func (fh *ForwardHandler) HandleStatusEvent(w http.ResponseWriter, body []byte) {
+func (fh *ForwardHandler) HandleStatusEvent(body []byte) error {
 	// for every other use of Tasks, Marathon uses the "id" field for the task ID.
 	// Here, it uses "taskId", with most of the other fields being equal. We'll
 	// just swap "taskId" for "id" in the body so that we can successfully parse
@@ -111,11 +103,9 @@ func (fh *ForwardHandler) HandleStatusEvent(w http.ResponseWriter, body []byte) 
 	body = bytes.Replace(body, []byte("taskId"), []byte("id"), -1)
 
 	task, err := tasks.ParseTask(body)
+
 	if err != nil {
-		w.WriteHeader(500)
-		fmt.Fprintln(w, err.Error())
-		log.Printf("[ERROR] body generated error: %s", err.Error())
-		return
+		return err
 	}
 
 	switch task.TaskStatus {
@@ -128,10 +118,8 @@ func (fh *ForwardHandler) HandleStatusEvent(w http.ResponseWriter, body []byte) 
 	}
 
 	if err != nil {
-		w.WriteHeader(500)
-		fmt.Fprintln(w, err.Error())
-	} else {
-		w.WriteHeader(200)
-		fmt.Fprintln(w, "OK")
+		return err
 	}
+
+	return nil
 }

--- a/web_test.go
+++ b/web_test.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
 	"github.com/CiscoCloud/marathon-consul/apps"
 	"github.com/CiscoCloud/marathon-consul/consul"
 	"github.com/CiscoCloud/marathon-consul/events"
 	"github.com/CiscoCloud/marathon-consul/mocks"
 	"github.com/CiscoCloud/marathon-consul/tasks"
 	"github.com/stretchr/testify/assert"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
 )
 
 var (
@@ -56,11 +57,8 @@ func TestForwardHandlerHandleAppEvent(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test!
-	recorder := httptest.NewRecorder()
-	handler.HandleAppEvent(recorder, body)
-
-	assert.Equal(t, 200, recorder.Code)
-	assert.Equal(t, "OK\n", recorder.Body.String())
+	err = handler.HandleAppEvent(body)
+	assert.Nil(t, err)
 
 	result, _, err := kv.Get(testApp.Key())
 	assert.Nil(t, err)
@@ -85,11 +83,8 @@ func TestForwardHandlerHandleTerminationEvent(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test!
-	recorder := httptest.NewRecorder()
-	handler.HandleTerminationEvent(recorder, body)
-
-	assert.Equal(t, 200, recorder.Code)
-	assert.Equal(t, "OK\n", recorder.Body.String())
+	err = handler.HandleTerminationEvent(body)
+	assert.Nil(t, err)
 
 	result, _, err := kv.Get(testApp.Key())
 	assert.Nil(t, err)
@@ -122,10 +117,8 @@ func TestForwardHandlerHandleStatusEvent(t *testing.T) {
 		assert.Nil(t, err)
 
 		// test
-		recorder := httptest.NewRecorder()
-		handler.HandleStatusEvent(recorder, tempBody)
-		assert.Equal(t, 200, recorder.Code)
-		assert.Equal(t, "OK\n", recorder.Body.String())
+		err = handler.HandleStatusEvent(tempBody)
+		assert.Nil(t, err)
 
 		// assert
 		result, _, err := kv.Get(testTask.Key())
@@ -139,10 +132,8 @@ func TestForwardHandlerHandleStatusEvent(t *testing.T) {
 		tempTask, _ := tasks.ParseTask(tempBody)
 
 		// test
-		recorder := httptest.NewRecorder()
-		handler.HandleStatusEvent(recorder, tempBody)
-		assert.Equal(t, 200, recorder.Code)
-		assert.Equal(t, "OK\n", recorder.Body.String())
+		err := handler.HandleStatusEvent(tempBody)
+		assert.Nil(t, err)
 
 		// assert
 		result, _, err := kv.Get(tempTask.Key())
@@ -156,8 +147,6 @@ func TestForwardHandlerHandleStatusEvent(t *testing.T) {
 
 	// bad status
 	tempBody := tempTaskBody("TASK_BATMAN")
-	recorder := httptest.NewRecorder()
-	handler.HandleStatusEvent(recorder, tempBody)
-	assert.Equal(t, 500, recorder.Code)
-	assert.Equal(t, "unknown task status\n", recorder.Body.String())
+	err := handler.HandleStatusEvent(tempBody)
+	assert.NotNil(t, err)
 }

--- a/web_test.go
+++ b/web_test.go
@@ -149,4 +149,5 @@ func TestForwardHandlerHandleStatusEvent(t *testing.T) {
 	tempBody := tempTaskBody("TASK_BATMAN")
 	err := handler.HandleStatusEvent(tempBody)
 	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "unknown task status")
 }


### PR DESCRIPTION
Hello! Thanks for creating a nice simple tool which glues together marathon and consul. We've been running it for a bit already and it looks promising for the future.

This branch adds support to autodetect if the version of Marathon is >= 0.9.0 (the version which introduces the /v2/events endpoint) and in that case, use the /v2/events endpoint rather than starting an HTTP server to receive the eventSubscription callbacks.

I'm a golang newcomer, so let me know if I've done anything super weird. Thanks.
