### PR TITLE
update task health status based on health_status_changed_event

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -62,3 +62,21 @@ func (event AppTerminatedEvent) Apps() []*apps.App {
 func (event AppTerminatedEvent) GetType() string {
 	return event.Type
 }
+
+type HealthStatusChangeEvent struct {
+	Type      string `json:"eventType"`
+	AppID     string `json:"appId"`
+	TaskID    string `json:"taskId"`
+	Timestamp string `json:"timestamp"`
+	Alive     bool   `json:"alive"`
+}
+
+func (event HealthStatusChangeEvent) Apps() []*apps.App {
+	return []*apps.App{
+		&apps.App{ID: event.AppID},
+	}
+}
+
+func (event HealthStatusChangeEvent) GetType() string {
+	return event.Type
+}

--- a/events/parse.go
+++ b/events/parse.go
@@ -43,6 +43,13 @@ func parseAppTerminatedEvent(jsonBlob []byte) (Event, error) {
 	return event, err
 }
 
+func parseHealthStatusChangeEvent(jsonBlob []byte) (Event, error) {
+	event := HealthStatusChangeEvent{}
+	err := json.Unmarshal(jsonBlob, &event)
+
+	return event, err
+}
+
 // ParseEvent combines the functions in this module to return an event without
 // the user having to worry about the *type* of the event.
 func ParseEvent(jsonBlob []byte) (event Event, err error) {
@@ -58,6 +65,9 @@ func ParseEvent(jsonBlob []byte) (event Event, err error) {
 		return parseDeploymentInfoEvent(jsonBlob)
 	case "app_terminated_event":
 		return parseAppTerminatedEvent(jsonBlob)
+	case "health_status_changed_event":
+		return parseHealthStatusChangeEvent(jsonBlob)
+
 	default:
 		return nil, errors.New("Unknown event type: " + eventType)
 	}

--- a/events/parse_test.go
+++ b/events/parse_test.go
@@ -53,3 +53,13 @@ func TestParseEvent_AppTerminatedEvent(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, event, parsed.(AppTerminatedEvent))
 }
+
+func TestParseEvent_HealthStatusChangeEvent(t *testing.T) {
+	event := HealthStatusChangeEvent{Type: "health_status_changed_event"}
+	jsonBlob, err := json.Marshal(event)
+	assert.Nil(t, err)
+
+	parsed, err := ParseEvent(jsonBlob)
+	assert.Nil(t, err)
+	assert.Equal(t, event, parsed.(HealthStatusChangeEvent))
+}

--- a/health/health.go
+++ b/health/health.go
@@ -1,0 +1,28 @@
+package health
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/CiscoCloud/marathon-consul/utils"
+)
+
+type Health struct {
+	AppID     string `json:"appId"`
+	TaskID    string `json:"taskId"`
+	Timestamp string `json:"timestamp"`
+	Alive     bool   `json:"alive"`
+}
+
+func ParseHealth(event []byte) (*Health, error) {
+	health := &Health{}
+	err := json.Unmarshal(event, health)
+	return health, err
+}
+
+func (health *Health) TaskKey() string {
+	return fmt.Sprintf(
+		"%s/tasks/%s",
+		utils.CleanID(health.AppID),
+		health.TaskID,
+	)
+}

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -1,0 +1,38 @@
+package health
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var testHealth = &Health{
+	AppID:     "/my-app",
+	TaskID:    "my-app_0-1396592784349",
+	Timestamp: "2014-03-01T23:29:30.158Z",
+	Alive:     true,
+}
+
+func TestParseHealth(t *testing.T) {
+	t.Parallel()
+
+	jsonified, err := json.Marshal(testHealth)
+	assert.Nil(t, err)
+
+	health, err := ParseHealth(jsonified)
+	assert.Nil(t, err)
+
+	assert.Equal(t, testHealth.AppID, health.AppID)
+	assert.Equal(t, testHealth.TaskID, health.TaskID)
+	assert.Equal(t, testHealth.Timestamp, health.Timestamp)
+	assert.Equal(t, testHealth.Alive, health.Alive)
+}
+
+func TestTaskKey(t *testing.T) {
+	t.Parallel()
+
+	tk := testHealth.TaskKey()
+
+	assert.Equal(t, fmt.Sprintf("%s/tasks/%s", "my-app", testHealth.TaskID), tk)
+}

--- a/main.go
+++ b/main.go
@@ -113,6 +113,8 @@ Reconnect:
 				case "status_update_event":
 					eventLogger.Info("handling event")
 					err = fh.HandleStatusEvent(body)
+				case "health_status_changed_event":
+					err = fh.HandleHealthStatusEvent(body)
 				default:
 					eventLogger.Info("not handling event")
 				}

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -51,11 +51,13 @@ func (task *Task) KV() *api.KVPair {
 func (task *Task) MarshalJSON() ([]byte, error) {
 	type Alias Task
 	return json.Marshal(&struct {
-		Healthy bool `json:"healthy"`
+		ReportsHealth bool `json:"reportsHealth"`
+		Healthy       bool `json:"healthy"`
 		*Alias
 	}{
-		Healthy: task.IsHealthy(),
-		Alias:   (*Alias)(task),
+		ReportsHealth: true,
+		Healthy:       task.IsHealthy(),
+		Alias:         (*Alias)(task),
 	})
 }
 

--- a/tasks/task_test.go
+++ b/tasks/task_test.go
@@ -8,14 +8,15 @@ import (
 )
 
 var testTask = &Task{
-	Timestamp:  "2014-03-01T23:29:30.158Z",
-	SlaveID:    "20140909-054127-177048842-5050-1494-0",
-	ID:         "my-app_0-1396592784349",
-	TaskStatus: "TASK_RUNNING",
-	AppID:      "/my-app",
-	Host:       "slave-1234.acme.org",
-	Ports:      []int{31372},
-	Version:    "2014-04-04T06:26:23.051Z",
+	Timestamp:          "2014-03-01T23:29:30.158Z",
+	SlaveID:            "20140909-054127-177048842-5050-1494-0",
+	ID:                 "my-app_0-1396592784349",
+	TaskStatus:         "TASK_RUNNING",
+	AppID:              "/my-app",
+	Host:               "slave-1234.acme.org",
+	Ports:              []int{31372},
+	Version:            "2014-04-04T06:26:23.051Z",
+	HealthCheckResults: []TaskHealthCheckResult{TaskHealthCheckResult{Alive: true}},
 }
 
 func TestParseTask(t *testing.T) {
@@ -35,6 +36,10 @@ func TestParseTask(t *testing.T) {
 	assert.Equal(t, testTask.Host, service.Host)
 	assert.Equal(t, testTask.Ports, service.Ports)
 	assert.Equal(t, testTask.Version, service.Version)
+	assert.Equal(t, testTask.HealthCheckResults, service.HealthCheckResults)
+
+	// check that derived field 'healthy' is serialized
+	assert.Contains(t, string(jsonified), "\"healthy\":true")
 }
 
 func TestKV(t *testing.T) {


### PR DESCRIPTION
Hi!  Thanks again for the great project.

As mentioned in https://github.com/CiscoCloud/marathon-consul/issues/24 , when using marathon-consul with haproxy-consul , we see tasks added to haproxy before they are healthy.

This PR adds a `HealthCheckResults` field to the Task (already reported by marathon), as well as a convenience `healthy` flag to make it easier to work with in templates.

Tasks health information is updated on receiving `health_status_changed_event` from marathon.

`healthy` is currently a bool, but in reality it's more of a tri-state (unknown, healthy, unhealthy).  currently it will report healthy=false unless there is a successful health check (again makes it easier to work with in templates).

I'd love any feedback to making this work better or to better integrate with the existing code.

thanks!
larry
